### PR TITLE
Type modified for ‘aeSI’ code

### DIFF
--- a/contentcodes.json
+++ b/contentcodes.json
@@ -235,7 +235,7 @@
 	},
 	"aeSI": {
 		"name": "com.apple.itunes.itms-songid",
-		"type": 5
+		"type": 7
 	},
 	"aeSL": {
 		"type": 1


### PR DESCRIPTION
I manage to get rid of the errors I had with iTunes Music Store previews (see https://github.com/roblan/shairport-sync-reader/pull/6).
The data who throws the error is always of type `core` with code `aeSI` and a `Buffer(8)` content.
By changing the type from `5` (int) to `7` (long) the error disappeared.